### PR TITLE
Fix module installation

### DIFF
--- a/6.x/mautic_tracker/mautic_tracker.info
+++ b/6.x/mautic_tracker/mautic_tracker.info
@@ -1,7 +1,7 @@
-name = Tracker
+name = Mautic Tracker
 description = Tracker for mautic
 package = Mautic
-version = VERSION
+version = 6.x-1.0
 core = 6.x
 files[] = mautic_tracker.module
 configure = admin/config/content/mautic_tracker

--- a/6.x/mautic_tracker/mautic_tracker.module
+++ b/6.x/mautic_tracker/mautic_tracker.module
@@ -33,7 +33,7 @@ function mautic_tracker_menu() {
     'description' => 'Configuration for Current posts module',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('mautic_tracker_form'),
-    'access arguments' => array('access administration'),
+    'access arguments' => array('access administration pages'),
     'type' => MENU_NORMAL_ITEM,
   );
 

--- a/7.x/mautic_tracker/mautic_tracker.info
+++ b/7.x/mautic_tracker/mautic_tracker.info
@@ -1,7 +1,7 @@
-name = Tracker
+name = Mautic Tracker
 description = Tracker for mautic
 package = Mautic
-version = VERSION
+version = 7.x-1.0
 core = 7.x
 files[] = mautic_tracker.module
 configure = admin/config/mautic

--- a/7.x/mautic_tracker/mautic_tracker.module
+++ b/7.x/mautic_tracker/mautic_tracker.module
@@ -36,7 +36,7 @@ function mautic_tracker_menu() {
     'description' => 'Configuration for Current posts module',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('mautic_tracker_form'),
-    'access arguments' => array('access administration'),
+    'access arguments' => array('access administration pages'),
     'type' => MENU_NORMAL_ITEM,
   );
 


### PR DESCRIPTION
We recently tried to install mautic_tracker in a Drupal 7 site, and had to make some changes:

In the .info file:
1.  The module name 'Tracker' is already used in Drupal core - changed it to 'Mautic Tracker'
2.  'version = VERSION' resulted in the version showing as the same as core.  I changed this to be more like a typical contrib module version.

Did the  same for the 6.x branch.

In the .module file:

In mautic_tracker_menu, the permission name should be 'access administration pages', not 'access administration'.  Made same change for 6.x branch.
