### PR TITLE
Correct content URL in block.

### DIFF
--- a/6.x/mautic_tracker/mautic_tracker.module
+++ b/6.x/mautic_tracker/mautic_tracker.module
@@ -67,10 +67,10 @@ function mautic_tracker_block($op = 'list', $delta = 0) {
     case 'view':
       switch ($delta) {
         case 0: 
-          $block['content'] = sprintf('<img src="%s/p/page/tracker.gif" />',variable_get('mautic_base_url', ''));
+          $block['content'] = sprintf('<img src="%s/p/mtracking.gif" />',variable_get('mautic_base_url', ''));
           break;
         case 1:
-          $block['content'] = sprintf('<img src="%s/p/page/tracker.gif" />',variable_get('mautic_base_url', ''));
+          $block['content'] = sprintf('<img src="%s/p/mtracking.gif" />',variable_get('mautic_base_url', ''));
           break;
       }
       return $block;

--- a/7.x/mautic_tracker/mautic_tracker.module
+++ b/7.x/mautic_tracker/mautic_tracker.module
@@ -76,7 +76,7 @@ function mautic_tracker_block_view($delta = '') {
   switch ($delta) {
     case 'mautic_tracker':
       $block['subject'] = t('mautic Tracker');
-      $block['content'] = sprintf('<img src="%s/p/page/tracker.gif" />',variable_get('mautic_base_url', ''));
+      $block['content'] = sprintf('<img src="%s/p/mtracking.gif" />',variable_get('mautic_base_url', ''));
       return $block;
       break; 
  }


### PR DESCRIPTION
This corrects the content URL in the block, using the path '/p/mtracking.gif' instead of '/p/page/tracker.gif'.
